### PR TITLE
Only attempt to load RAMLs whose names start with i

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ COPY yarn.lock .
 RUN yarn install
 COPY . .
 EXPOSE 3000
-CMD yarn start tests/mod-inventory-storage-ramls/*.raml
+CMD yarn start tests/mod-inventory-storage-ramls/i*.raml


### PR DESCRIPTION
Something that I have not yet investigated means that this breaks when
trying to load all the RAMLs at once. For now, I just want this to
work, so we can get onto the next critical-path problem.