### PR TITLE
FOLIO-2235 Add default LaunchDescriptor settings

### DIFF
--- a/ModuleDescriptor.json
+++ b/ModuleDescriptor.json
@@ -15,9 +15,12 @@
   ],
   "launchDescriptor": {
     "dockerImage": "mod-graphql:0.1.0",
+    "dockerPull": false,
     "dockerArgs": {
-      "HostConfig": { "PortBindings": { "3001/tcp":  [{ "HostPort": "%p" }] } }
-    },
-    "dockerPull" : false
+      "HostConfig": {
+        "Memory": 268435456,
+        "PortBindings": { "3001/tcp": [ { "HostPort": "%p" } ] }
+      }
+    }
   }
 }


### PR DESCRIPTION
Add basic container memory setting 256MB

Enables ready default deployment.
Refer to [FOLIO-2235](https://issues.folio.org/browse/FOLIO-2235) and [documentation](https://dev.folio.org/guides/module-descriptor/#launchdescriptor-properties).
