### PR TITLE
MODGQL-130: Date-and-time vulnerability (CVE-2020-26289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for mod-graphql
 
+## not yet released
+
+* Bump date-and-time from 0.5.0 to 0.14.2 fixing a regular expression denial of service (ReDoS) vulnerability. Fixes [CVE-2020-26289](https://nvd.nist.gov/vuln/detail/CVE-2020-26289), [MODGQL-130](https://issues.folio.org/browse/MODGQL-130).
+* Bump elliptic from 6.5.3 to 6.5.4 fixing a ECDH secp256k1 cryptographic vulnerability. Fixes [CVE-2020-28498](https://nvd.nist.gov/vuln/detail/CVE-2020-28498).
+
 ## [1.6.0](https://github.com/folio-org/mod-graphql/tree/v1.6.0) (2021-02-23)
 [Full Changelog](https://github.com/folio-org/mod-graphql/compare/v1.5.0...v1.6.0)
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "yakbak": "^4.0.0"
   },
   "resolutions": {
-    "date-and-time": "0.14.2"
+    "date-and-time": "^0.14.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "path": "^0.12.7",
     "url": "^0.11.0",
     "yakbak": "^4.0.0"
+  },
+  "resolutions": {
+    "date-and-time": "0.14.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2510,10 +2510,10 @@ damerau-levenshtein@^1.0.4:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz#143c1641cb3d85c60c32329e26899adea8701791"
   integrity sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==
 
-date-and-time@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.5.0.tgz#48a1538c09289188746311fc1f0c7b3351736d48"
-  integrity sha512-ltkWbWrpst4Ymjt0Ksv7wiVLlU05i73mzc/CQ0nYMno+nl8SFKp47qgov9STRnpDOWpfMHoK2K9bMUcKt59Utg==
+date-and-time@0.14.2, date-and-time@0.5.0:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.14.2.tgz#a4266c3dead460f6c231fe9674e585908dac354e"
+  integrity sha512-EFTCh9zRSEpGPmJaexg7HTuzZHh6cnJj1ui7IGCFNXzd2QdpsNh05Db5TF3xzJm30YN+A8/6xHSuRcQqoc3kFA==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
Bump date-and-time from 0.5.0 to 0.14.2 fixing the
regular expression denial of service (ReDoS) vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2020-26289

We need to use "resolutions" because the intermediate
dependencies raml-1-parser, raml-definition-system, and
raml-typesystem are no longer supported and don't
provide updates.