### PR TITLE
MODGQL-142: Update node.js version from 10 to 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:14
 WORKDIR /usr/src/app
 # Copying these separately prevents node_modules
 # being reinstalled on other changes


### PR DESCRIPTION
The Jenkins build pipeline of the HEAD of master fails with this error message:

error incoming-message-hash@4.1.0: The engine "node" is incompatible with this module. Expected version ">=12". Got "10.24.1"
error Found incompatible module.

Switch node.js version from 10 to 14. FOLIO usually uses node.js 14:
https://issues.folio.org/browse/FOLIO-3324