### PR TITLE
MODGQL-143: validator 13.7.0 fixing ReDoS (CVE-2021-3765)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "date-and-time": "^0.14.2",
     "json-ptr": "^2.2.0",
     "underscore": "^1.13.1",
+    "validator": "^13.7.0",
     "xmldom": "^0.6.0"
   }
 }


### PR DESCRIPTION
validator < 13.7.0 is vulnerable to a ReDoS attack (Regular Expression Denial of Service caused by Inefficient Regular Expression Complexity): https://nvd.nist.gov/vuln/detail/CVE-2021-3765

mod-graphql requires z-schema@3.21.0 requires validator@^10.0.0.