### PR TITLE
MODGQL-149: Dockerfile: node:16-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM node:14
+FROM node:16-alpine
 WORKDIR /usr/src/app
-# Copying these separately prevents node_modules
-# being reinstalled on other changes
-COPY package.json .
-COPY yarn.lock .
-RUN yarn install
 COPY . .
-RUN ./tests/setup.sh
+RUN yarn install \
+ && ./tests/setup.sh \
+ && rm -rf node_modules/ \
+ && yarn install --production \
+ && yarn cache clean
 EXPOSE 3001
 CMD yarn start tests/input/*/ramls/*.raml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM node:16-alpine
 WORKDIR /usr/src/app
+
+# Create a Docker build stage cache layer with node_modules only
+# to skip yarn install when package.json doesn't change
+# https://stackoverflow.com/questions/35774714
+COPY package.json .
+COPY yarn.lock .
+RUN yarn install
+
 COPY . .
-RUN yarn install \
- && ./tests/setup.sh \
- && rm -rf node_modules/ \
- && yarn install --production \
- && yarn cache clean
+RUN ./tests/setup.sh
 EXPOSE 3001
 CMD yarn start tests/input/*/ramls/*.raml


### PR DESCRIPTION
Update Node from 14 to 16, the current Active LTS version.
Node 14 became Maintenance LTS on 2021-10-19.

Switch from Debian 8 (Stretch) to Alpine 3.15.
Stretch doesn't provide security updates for Node.js:
https://www.debian.org/releases/stretch/i386/release-notes/ch-information.en.html#limited-security-support
Stretch general LTS security support ends June 30, 2022:
https://wiki.debian.org/LTS
Alpine 3.15 security support ends 2023-11-01:
https://alpinelinux.org/releases/

These changes reduce the Docker container image size
from 1270 MB to 432 MB.