### PR TITLE
MODGQL-150: Use multi-stage build to reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,9 @@ COPY yarn.lock .
 FROM base AS production
 RUN yarn install --production
 
-FROM production AS test
-RUN yarn install
-
-COPY . .
-RUN ./tests/setup.sh
-
 FROM base AS release
 COPY --from=production /usr/src/app/node_modules/ /usr/src/app/node_modules/
 COPY . .
+RUN ./tests/setup.sh
 EXPOSE 3001
 CMD yarn start tests/input/*/ramls/*.raml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
-FROM node:14
+FROM node:14 AS base
 WORKDIR /usr/src/app
-# Copying these separately prevents node_modules
-# being reinstalled on other changes
+
+# Create a Docker build stage cache layer with node_modules only
+# to skip yarn install when package.json doesn't change
+# https://stackoverflow.com/questions/35774714
 COPY package.json .
 COPY yarn.lock .
+
+FROM base AS production
+RUN yarn install --production
+
+FROM production AS test
 RUN yarn install
 COPY . .
 RUN ./tests/setup.sh
+
+FROM base AS release
+COPY --from=production /usr/src/app/node_modules/ /usr/src/app/node_modules/
+COPY . .
 EXPOSE 3001
 CMD yarn start tests/input/*/ramls/*.raml


### PR DESCRIPTION
This reduces the Docker images size from 428 MB to 213 MB.