### PR TITLE
MODGQL-151: Add .git to .dockerignore to reduce Docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
+.git
 node_modules
 npm-debug.log


### PR DESCRIPTION
This reduces the Docker image size by the size of the .git directory. Currently it is 5 MB big.