### PR TITLE
Extension to `create-schemas`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for mod-graphql
 
+## [1.10.0](https://github.com/folio-org/mod-graphql/tree/v1.10.0) (2021-06-24)
+[Full Changelog](https://github.com/folio-org/mod-graphql/compare/v1.9.0...v1.10.0)
+
+* Extensions to `create-schema.js` to help with handling OpenAPI-based modules. Fixes MODGQL-153.
+
 ## [1.9.0](https://github.com/folio-org/mod-graphql/tree/v1.9.0) (2021-06-03)
 [Full Changelog](https://github.com/folio-org/mod-graphql/compare/v1.8.0...v1.9.0)
 

--- a/create-schemas/.gitignore
+++ b/create-schemas/.gitignore
@@ -2,5 +2,6 @@ mod-inventory-storage
 mod-inventory-storage-overlaid
 mod-inventory-storage-rewritten
 mod-inventory-storage-virgin
+mod-search
 node_modules
 yarn.lock

--- a/create-schemas/Makefile
+++ b/create-schemas/Makefile
@@ -19,7 +19,7 @@ mod-inventory-storage-overlaid:
 	mv mod-inventory-storage $@
 
 clean:
-	rm -rf mod-inventory-storage*
+	rm -rf mod-inventory-storage* mod-search
 
 distclean: clean
 	rm -rf node_modules yarn.lock

--- a/create-schemas/README.md
+++ b/create-schemas/README.md
@@ -5,7 +5,7 @@ This area contains a stand-alone utility that downloads the RAMLs and JSON Schem
 
 ## Overview
 
-In short, you write [a JSON configuration file](schemaconf.json) specifying which back-end modules are to be supported, which releases of those modules to use, and what overlays to add to the canonical versions of the release's JSON Schemas. Then you run [the `create-schemas.js` script](create-schemas.js) with the `--overlay` option. It will download the RAMLS and JSON schemas of the specified releases of the specified modules, then apply the overlays specified in the configuration. `mod-graphql` can then be run against the resulting overlaid schemas which can include whatever new links we need. (As a bonus, this also implements a much more terse way of specifying link-fields in a single line -- see below.)
+In short, you write [a JSON configuration file](schemaconf.json) specifying which back-end modules are to be supported, which releases of those modules to use, and what overlays to add to the canonical versions of the release's JSON Schemas. Then you run [the `create-schemas.js` script](create-schemas.js) with the `--overlay` option. It will download the RAMLs and JSON schemas of the specified releases of the specified modules, then apply the overlays specified in the configuration. `mod-graphql` can then be run against the resulting overlaid schemas which can include whatever new links we need. (As a bonus, this also implements a much more terse way of specifying link-fields in a single line -- see below.)
 
 
 ## Configuration file format
@@ -17,6 +17,7 @@ At the top level is an array containing one entry for each FOLIO back-end module
 Each entry is an object with three keys:
 * `module` -- the name of the module: specifically, the name of the GitHub repository in which its source-code is found, which is almost always the same thing. Example: `mod-inventory-storage`
 * `release` -- the three-part (_major_._minor_._patch_) version-number of the release to be used. Example: `19.4.0`
+* `ramlPath` -- if specified, the path within the module where the RAMLs are found, which is renamed to be the `ramls` directory in the local copy that is downloaded. If omitted, the default top-level `ramls` directory is used as-is.
 * `overlays` (optional): an array of overlays to be applied to the JSON Schemas of the module. See below. If omitted, then the RAMLs and JSON Schemas of the module are used as they appear in the specified release.
 
 The `overlays` value is an object whose keys are the names of JSON Schema files in the module's `ramls` directory. Example: `instance.json`.

--- a/create-schemas/README.md
+++ b/create-schemas/README.md
@@ -17,8 +17,9 @@ At the top level is an array containing one entry for each FOLIO back-end module
 Each entry is an object with three keys:
 * `module` -- the name of the module: specifically, the name of the GitHub repository in which its source-code is found, which is almost always the same thing. Example: `mod-inventory-storage`
 * `release` -- the three-part (_major_._minor_._patch_) version-number of the release to be used. Example: `19.4.0`
-* `ramlPath` -- if specified, the path within the module where the RAMLs are found, which is renamed to be the `ramls` directory in the local copy that is downloaded. If omitted, the default top-level `ramls` directory is used as-is.
-* `overlays` (optional): an array of overlays to be applied to the JSON Schemas of the module. See below. If omitted, then the RAMLs and JSON Schemas of the module are used as they appear in the specified release.
+* `ramlPath` (optional) -- the path within the module where the RAMLs are found, which is renamed to be the `ramls` directory in the local copy that is downloaded. If omitted, the default top-level `ramls` directory is used as-is.
+* `copyFiles` (optional) -- an array of names of files which are copied into the locally copied `ramls` directory. Useful for supplying a locally-provided RAML file if the module uses OpenAPI.
+* `overlays` (optional) -- an array of overlays to be applied to the JSON Schemas of the module. See below. If omitted, then the RAMLs and JSON Schemas of the module are used as they appear in the specified release.
 
 The `overlays` value is an object whose keys are the names of JSON Schema files in the module's `ramls` directory. Example: `instance.json`.
 

--- a/create-schemas/create-schemas.js
+++ b/create-schemas/create-schemas.js
@@ -50,7 +50,7 @@ function createModuleSchemas(moduleConfig, options) {
   if (options.rewrite || options.overlay) {
     if (copyFiles) {
       copyFiles.forEach(entry => {
-        system(`cp ${entry} ${module}/`);
+        system(`cp ${entry} ${module}/ramls/`);
       });
     }
 

--- a/create-schemas/create-schemas.js
+++ b/create-schemas/create-schemas.js
@@ -36,13 +36,13 @@ function createSchemas(config, options) {
 
 
 function createModuleSchemas(moduleConfig, options) {
-  const { module, release, overlays } = moduleConfig;
+  const { module, release, ramlPath, overlays } = moduleConfig;
 
   if (options.fetch) {
     system(`rm -rf ${module}`);
   }
   if (!fs.existsSync(module)) {
-    obtainSchemas(module, release);
+    obtainSchemas(module, release, ramlPath);
   }
 
   if ((options.rewrite || options.overlay) && overlays) {
@@ -57,7 +57,7 @@ function createModuleSchemas(moduleConfig, options) {
 }
 
 
-function obtainSchemas(module, release) {
+function obtainSchemas(module, release, ramlPath) {
   console.log(`Obtaining schemas for ${module} ${release}`);
 
   // There may be a better way to do this, but cloning the source from
@@ -68,7 +68,7 @@ function obtainSchemas(module, release) {
   process.chdir(module);
   system(`git checkout --quiet ${release}`);
   process.chdir('..');
-  system(`mv ${module}/ramls .`);
+  system(`mv ${module}/${ramlPath || 'ramls'} ramls`);
   system(`rm -rf ${module}`);
   system(`mkdir ${module}`);
   system(`mv ramls ${module}`);

--- a/create-schemas/create-schemas.js
+++ b/create-schemas/create-schemas.js
@@ -1,30 +1,32 @@
 #!/usr/bin/env node
 
-const getopts = require("getopts")
+/* eslint-disable no-console, no-use-before-define, no-param-reassign */
+
+const getopts = require('getopts');
 const fs = require('fs');
 const execSync = require('child_process').execSync;
 const jp = require('jsonpath');
 
-const options = getopts(process.argv.slice(2), {
+const globalOptions = getopts(process.argv.slice(2), {
   boolean: ['help', 'fetch', 'rewrite', 'overlay'],
   alias: {
-    h: "help",
+    h: 'help',
   },
   default: {
     fetch: false,
     rewrite: false,
     overlay: false,
   }
-})
+});
 
-if (options.help || options._.length !== 1) {
+if (globalOptions.help || globalOptions._.length !== 1) {
   console.error(`Usage: ${process.argv[1]} [--(no-)fetch] [--(no-)rewrite] [--(no-)overlay] schemaconf.json`);
-  process.exit(1)
+  process.exit(1);
 }
 
-const configName = options._[0];
-const config = parseSchema(configName);
-createSchemas(config, options);
+const configName = globalOptions._[0];
+const globalConfig = parseSchema(configName);
+createSchemas(globalConfig, globalOptions);
 process.exit(0);
 
 
@@ -121,10 +123,11 @@ function expandOverlaySummary(summary) {
   const regexp = /^(.*?) (.*?)\?(.*?)=(.*?) (.*)$/;
   const res = summary.match(regexp);
   if (!res) {
-    throw(Error(`bad overlay summary: '${summary}'`));
+    throw Error(`bad overlay summary: '${summary}'`);
   }
 
-  const [ undefined, schemaRef, linkBase, linkToField, linkFromField, includedElement ] = res;
+  // eslint-disable-next-line no-unused-vars
+  const [__UNUSED, schemaRef, linkBase, linkToField, linkFromField, includedElement] = res;
   return {
     'type': 'object',
     'folio:$ref': schemaRef,
@@ -134,7 +137,7 @@ function expandOverlaySummary(summary) {
     'folio:linkFromField': linkFromField,
     'folio:linkToField': linkToField,
     'folio:includedElement': includedElement,
-  }
+  };
 }
 
 

--- a/create-schemas/create-schemas.js
+++ b/create-schemas/create-schemas.js
@@ -38,7 +38,7 @@ function createSchemas(config, options) {
 
 
 function createModuleSchemas(moduleConfig, options) {
-  const { module, release, ramlPath, overlays } = moduleConfig;
+  const { module, release, ramlPath, copyFiles, overlays } = moduleConfig;
 
   if (options.fetch) {
     system(`rm -rf ${module}`);
@@ -47,14 +47,22 @@ function createModuleSchemas(moduleConfig, options) {
     obtainSchemas(module, release, ramlPath);
   }
 
-  if ((options.rewrite || options.overlay) && overlays) {
-    Object.keys(overlays).sort().forEach(schemaName => {
-      if (options.overlay) {
-        handleOverlaysForSchema(module, schemaName, overlays[schemaName]);
-      } else {
-        console.log(` Skipping overlays for schema ${schemaName}`);
-      }
-    });
+  if (options.rewrite || options.overlay) {
+    if (copyFiles) {
+      copyFiles.forEach(entry => {
+        system(`cp ${entry} ${module}/`);
+      });
+    }
+
+    if (overlays) {
+      Object.keys(overlays).sort().forEach(schemaName => {
+        if (options.overlay) {
+          handleOverlaysForSchema(module, schemaName, overlays[schemaName]);
+        } else {
+          console.log(` Skipping overlays for schema ${schemaName}`);
+        }
+      });
+    }
   }
 }
 

--- a/create-schemas/etc/mod-search-instances.raml
+++ b/create-schemas/etc/mod-search-instances.raml
@@ -34,7 +34,7 @@ resourceTypes:
       exampleItem: !include  examples/instance_get.json
   get:
     is: [pageable,
-	searchable: {description: "by title (using CQL)",
-		      example: "title=\"*uproot*\""},
-	]
+        searchable: {description: "by title (using CQL)",
+                      example: "title=\"*uproot*\""},
+        ]
 

--- a/create-schemas/etc/mod-search-instances.raml
+++ b/create-schemas/etc/mod-search-instances.raml
@@ -1,0 +1,40 @@
+#%RAML 1.0
+title: Instance searching in mod-search
+version: v0.8
+protocols: [ HTTP, HTTPS ]
+baseUri: http://localhost
+
+documentation:
+  - title: Instance Storage API
+    content: <b>Storage for instances in the inventory</b>
+
+types:
+  instance: !include instance.json
+  instances: !include instances.json
+  marcJson: !include marc.json
+  instanceRelationship: !include instancerelationship.json
+  instanceRelationships: !include instancerelationships.json
+
+traits:
+  language: !include raml-util/traits/language.raml
+  pageable: !include raml-util/traits/pageable.raml
+  searchable: !include raml-util/traits/searchable.raml
+
+resourceTypes:
+  collection: !include raml-util/rtypes/collection.raml
+  collection-item: !include raml-util/rtypes/item-collection.raml
+
+/instances:
+  displayName: Get a list of instances for CQL query
+  type:
+    collection:
+      exampleCollection: !include  examples/instances_get.json
+      schemaCollection: instances
+      schemaItem: instance
+      exampleItem: !include  examples/instance_get.json
+  get:
+    is: [pageable,
+	searchable: {description: "by title (using CQL)",
+		      example: "title=\"*uproot*\""},
+	]
+

--- a/create-schemas/schemaconf.json
+++ b/create-schemas/schemaconf.json
@@ -47,6 +47,9 @@
     "module": "mod-search",
     "release": "v1.6.4",
     "ramlPath": "src/main/resources/swagger.api",
+    "copyFiles": [
+      "etc/mod-search-instances.raml"
+    ],
     "overlays": {}
   }
 ]

--- a/create-schemas/schemaconf.json
+++ b/create-schemas/schemaconf.json
@@ -42,5 +42,11 @@
         "itemLevelCallNumberTypeObject2": "callnumbertype.json call-number-types?id=itemLevelCallNumberTypeId callNumberTypes.0"
       }
     }
+  },
+  {
+    "module": "mod-search",
+    "release": "v1.6.4",
+    "ramlPath": "src/main/resources/swagger.api",
+    "overlays": {}
   }
 ]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "main.js",
   "license": "Apache-2.0",
   "scripts": {
-    "lint": "eslint create-schemas/create-schemas.js main.js src src/autogen/raml2graphql tests/*.js tests/testlib/*.js",
+    "lint": "eslint -f unix create-schemas/create-schemas.js main.js src src/autogen/raml2graphql tests/*.js tests/testlib/*.js",
     "start": "babel-node --presets=env,stage-2 main.js",
     "dev": "nodemon --exec babel-node --presets=env,stage-2 main.js",
     "test": "./tests/setup.sh && mocha --exit --require tests/testlib/support tests",


### PR DESCRIPTION
This commit adds extensions to the `create-schemas.js` script that make it capable of handling modules that it previously could not -- specifically, those that use OpenAPI rather than RAML. There are two principal changes:
1. *`create-schemas` supports an optional module-specific `ramlPath` configuration element*. When this is specified in one of the module stanzas of the `schemaconf.json` file, the downloaded copy's `ramls` directory is a copy not of the original's `ramls`, but of the specified directory. As well and being generally more flexible, this is a step towards supporting modules whose APIs are expressed in OpenAPI and follow the corresponding file-layout conventions.
2. *`create-schemas supports an optional module-specific `copyFiles` configuration element*. When this is specified in one of the module stanzas of the `schemaconf.json` file, each file specified in the array value is copied into the downloaded copy's `ramls` directory. This gives us a way to provide RAML files for modules whose APIs are expressed in OpenAPI.

In addition, there are some smaller changes
* The `lint` script in the package file now emits messages in Unix format.
* `create-schemas.js` script is now lint-clean (in part because it turns off some of the sillier rules).
* Some dependencies have been updated.

Fixes MODGQL-152.
