### PR TITLE
Copy mod-inventory-storage JSON schemas for mod-search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for mod-graphql
 
+## [1.10.2](https://github.com/folio-org/mod-graphql/tree/v1.10.2) (IN PROGRESS)
+[Full Changelog](https://github.com/folio-org/mod-graphql/compare/v1.10.1...v1.10.2)
+
+* Copy mod-inventory-storage JSON schemas for mod-search, instead of having mod-search's RAML link out to the adjacent mod-inventory-storage area. Avoids error "duplicate type name 'Tinstances' with different definitions" when starting up mod-graphql on both modules simultaneously. Fixes MODGQL-156.
+
 ## [1.10.1](https://github.com/folio-org/mod-graphql/tree/v1.10.1) (2022-06-25)
 [Full Changelog](https://github.com/folio-org/mod-graphql/compare/v1.10.0...v1.10.1)
 

--- a/create-schemas/create-schemas.js
+++ b/create-schemas/create-schemas.js
@@ -50,7 +50,7 @@ function createModuleSchemas(moduleConfig, options) {
   if (options.rewrite || options.overlay) {
     if (copyFiles) {
       copyFiles.forEach(entry => {
-        system(`cp ${entry} ${module}/ramls/`);
+        system(`cp -r ${entry} ${module}/ramls/`);
       });
     }
 

--- a/create-schemas/etc/mod-search-instances.raml
+++ b/create-schemas/etc/mod-search-instances.raml
@@ -9,27 +9,27 @@ documentation:
     content: <b>Storage for instances in the inventory</b>
 
 types:
-  instance: !include ../../mod-inventory-storage/ramls/instance.json
-  instances: !include ../../mod-inventory-storage/ramls/instances.json
+  instance: !include instance.json
+  instances: !include instances.json
 
 traits:
-  language: !include ../../mod-inventory-storage/ramls/raml-util/traits/language.raml
-  pageable: !include ../../mod-inventory-storage/ramls/raml-util/traits/pageable.raml
-  searchable: !include ../../mod-inventory-storage/ramls/raml-util/traits/searchable.raml
+  language: !include raml-util/traits/language.raml
+  pageable: !include raml-util/traits/pageable.raml
+  searchable: !include raml-util/traits/searchable.raml
 
 resourceTypes:
-  collection: !include ../../mod-inventory-storage/ramls/raml-util/rtypes/collection.raml
-  collection-item: !include ../../mod-inventory-storage/ramls/raml-util/rtypes/item-collection.raml
+  collection: !include raml-util/rtypes/collection.raml
+  collection-item: !include raml-util/rtypes/item-collection.raml
 
 /search:
   /instances:
     displayName: Get a list of instances for CQL query
     type:
       collection:
-        exampleCollection: !include  ../../mod-inventory-storage/ramls/examples/instances_get.json
+        exampleCollection: !include examples/instances_get.json
         schemaCollection: instances
         schemaItem: instance
-        exampleItem: !include ../../mod-inventory-storage/ramls/examples/instance_get.json
+        exampleItem: !include examples/instance_get.json
     get:
       is: [pageable,
           searchable: {description: "by title (using CQL)",

--- a/create-schemas/schemaconf.json
+++ b/create-schemas/schemaconf.json
@@ -48,7 +48,10 @@
     "release": "v1.6.4",
     "ramlPath": "src/main/resources/swagger.api",
     "copyFiles": [
-      "etc/mod-search-instances.raml"
+      "etc/mod-search-instances.raml",
+      "mod-inventory-storage/ramls/*.json",
+      "mod-inventory-storage/ramls/raml-util",
+      "mod-inventory-storage/ramls/examples"
     ],
     "overlays": {}
   }

--- a/tests/schemaconf.json
+++ b/tests/schemaconf.json
@@ -16,8 +16,10 @@
     "release": "v1.6.4",
     "ramlPath": "src/main/resources/swagger.api",
     "copyFiles": [
-      "../../create-schemas/etc/mod-search-instances.raml"
-    ],
-    "overlays": {}
+      "../../create-schemas/etc/mod-search-instances.raml",
+      "mod-inventory-storage/ramls/*.json",
+      "mod-inventory-storage/ramls/raml-util",
+      "mod-inventory-storage/ramls/examples"
+    ]
   }
 ]


### PR DESCRIPTION
Using copies local to the mod-search RAML rather than having the RAML refer to the copies in the mod-inventory-storage area, allow the types generated for the two modules to be identical rather than merely equivalent. This means that mod-graphql doesn't reject them on startup saying

> duplicate type name 'Tinstances' with different definitions

Fixes MODGQL-156.