### PR TITLE
Changing path to mod-search

### DIFF
--- a/create-schemas/schemaconf.json
+++ b/create-schemas/schemaconf.json
@@ -48,7 +48,7 @@
     "release": "v1.6.4",
     "ramlPath": "src/main/resources/swagger.api",
     "copyFiles": [
-      "etc/mod-search-instances.raml",
+      "create-schemas/etc/mod-search-instances.raml",
       "mod-inventory-storage/ramls/*.json",
       "mod-inventory-storage/ramls/raml-util",
       "mod-inventory-storage/ramls/examples"


### PR DESCRIPTION
Noticed this while debugging our docker entrypoint. I think that these paths are relative to the base. When running create-schemas.js I got a file not found for the search one. But the others worked fine.

Related quibble about the readme:

It seems like in the [readme](https://github.com/folio-org/mod-graphql/blob/master/create-schemas/README.md#using-the-resulting-ramls-and-json-schemas) too that a directory called `schemas` might be where the copied ramls are placed as a group, but from what I can tell the `create-schemas.js` just puts the copied files into directories relative to the base as well.

If they are relative to the base I think the pattern to pass to yarn would be `yarn start mod-*/ramls/*.raml`.