### PR TITLE
FOLIO-3231 Remove old config API doc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,6 @@ buildNPM {
   npmDeploy = false
   runLint = false
   runTest = true
-  publishAPI = false
   publishModDescriptor = true
   modDescriptor = 'ModuleDescriptor.json'
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-graphql
 
-Copyright (C) 2017-2020 The Open Library Foundation
+Copyright (C) 2017-2022 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.


### PR DESCRIPTION
The Jenkinsfile setting was 'false' (which is the default) so not being used. This is a deprecated configuration property, and was only relevant for Maven-based repositories.

In the future, there will be GitHub Workflows for api-lint and api-doc FOLIO-3202 FOLIO-3203. So if it is relevant to describe APIs of mod-graphql itself, then they might be used.