### PR TITLE
MODGQL-161: query-string ^7.1.2 fixing DoS CVE-2022-38900

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",
     "node-getopt": "^0.3.2",
-    "query-string": "^5.0.1",
+    "query-string": "^7.1.2",
     "raml-1-parser": "1.1.47"
   },
   "devDependencies": {


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-38900