### PR TITLE
Generated type names include WSAPI path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Upgrade to `query-string` ^7.1.2, mitigating DoS CVE-2022-38900. Fixes MODGQL-161.
 * When parsing JSON schemas, infer that arrays whose elements specify no type are of type `object`, so long as a `$ref` field is provided. This allows us to correctly handle the `mod-search` JSON schemas, which routinely omit array-element types. This functionality is provided by `graphql` interface 1.3. Fixes MODGQL-164.
 * A new, self-contained [`build` directory](build) is used for building the Docker container. This is now distinct from the [`tests`](tests) directory used for running tests (as it always should have been) and from the schema-configuration file and hand-crafted `mod-search` RAML that are used in development of the [`create-schemas`](create-schemas) part of the software. Fixes MODGQL-158.
+* Generated type names now include a prefix representing the WSAPI path, disambiguating otherwise same-named types from different modules. This prevents same-named schemas with different contents from colliding. Fixes MODGQL-114.
+* The fix to type names enables `mod-inventory-storage` and `mod-search` to run together. Fixes MODGQL-165.
 
 ## [1.10.2](https://github.com/folio-org/mod-graphql/tree/v1.10.2) (2022-06-25)
 [Full Changelog](https://github.com/folio-org/mod-graphql/compare/v1.10.1...v1.10.2)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "babel-node --presets=env,stage-2 main.js",
     "dev": "nodemon --exec babel-node --presets=env,stage-2 main.js",
     "test": "./tests/setup-for-tests.sh && ./build/setup-for-build.sh && mocha --exit --require tests/testlib/support tests",
-    "test1": "./tests/setup-for-tests.sh && ./build/setup-for-build.sh && mocha --exit --require tests/testlib/support tests/20-merge-production-schemas.js",
+    "test1": "./tests/setup-for-tests.sh && ./build/setup-for-build.sh && mocha --exit --require tests/testlib/support tests/20-merge-toy-schemas.js",
     "clean": "rm -rf api.yml tests/schemas-for-tests",
     "regen": "node src/autogen/test/run-tests.js --regenerate ./src/autogen/test",
     "api": "rm -f api.yml; wget https://raw.githubusercontent.com/folio-org/folio-org.github.io/master/_data/api.yml"

--- a/src/autogen/gatherAPI.js
+++ b/src/autogen/gatherAPI.js
@@ -346,7 +346,7 @@ function gatherResource(raml10types, resource, basePath, schemaMap, types, optio
         const schemaDir = schemaMap[schemaName];
         const currentPath = (schemaDir && schemaDir !== '.') ? `${basePath}/${schemaDir}` : basePath;
         // console.log(`* schema '${schemaName}' with dir '${schemaDir}': currentPath = '${currentPath}'`);
-        result.type = insertSchema(basePath, currentPath, types, options, schemaName, schemaText);
+        result.type = insertSchema(basePath, currentPath, types, options, result.queryName + '__' + schemaName, schemaText);
       } else if (!options.allowSchemaless) {
         throw new Error(`no schema for '${result.queryName}': cannot find get/responses/200/body/schema or get/body/schema for '${result.url}'`);
       }

--- a/src/autogen/test/graphql-schemas/01-inline-schema.graphql
+++ b/src/autogen/test/graphql-schemas/01-inline-schema.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): Tgenerated1
+  person(name: String, maxCount: Float, queryString: String): Tperson__generated1
 }
 
-type Tgenerated1 {
+type Tperson__generated1 {
   address: String
   name: String
 }

--- a/src/autogen/test/graphql-schemas/02-required-clause.graphql
+++ b/src/autogen/test/graphql-schemas/02-required-clause.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): Tgenerated1
+  person(name: String, maxCount: Float, queryString: String): Tperson__generated1
 }
 
-type Tgenerated1 {
+type Tperson__generated1 {
   address: String
   name: String!
 }

--- a/src/autogen/test/graphql-schemas/03-extracted-schema.graphql
+++ b/src/autogen/test/graphql-schemas/03-extracted-schema.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): TpersonType
+  person(name: String, maxCount: Float, queryString: String): Tperson__personType
 }
 
-type TpersonType {
+type Tperson__personType {
   address: String
   name: String!
 }

--- a/src/autogen/test/graphql-schemas/04-extracted-resource-type.graphql
+++ b/src/autogen/test/graphql-schemas/04-extracted-resource-type.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): Tgenerated1
+  person(name: String, maxCount: Float, queryString: String): Tperson__generated1
 }
 
-type Tgenerated1 {
+type Tperson__generated1 {
   address: String
   name: String!
 }

--- a/src/autogen/test/graphql-schemas/05-extracted-schema.graphql
+++ b/src/autogen/test/graphql-schemas/05-extracted-schema.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): TpersonSchema
+  person(name: String, maxCount: Float, queryString: String): Tperson__personSchema
 }
 
-type TpersonSchema {
+type Tperson__personSchema {
   address: String
   name: String!
 }

--- a/src/autogen/test/graphql-schemas/06-external-schema.graphql
+++ b/src/autogen/test/graphql-schemas/06-external-schema.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): TpersonSchema
+  person(name: String, maxCount: Float, queryString: String): Tperson__personSchema
 }
 
-type TpersonSchema {
+type Tperson__personSchema {
   address: String
   name: String!
 }

--- a/src/autogen/test/graphql-schemas/07-body-defined-for-method.graphql
+++ b/src/autogen/test/graphql-schemas/07-body-defined-for-method.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): TpersonSchema
+  person(name: String, maxCount: Float, queryString: String): Tperson__personSchema
 }
 
-type TpersonSchema {
+type Tperson__personSchema {
   address: String
   name: String!
 }

--- a/src/autogen/test/graphql-schemas/08-body-defined-at-two-levels.graphql
+++ b/src/autogen/test/graphql-schemas/08-body-defined-at-two-levels.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): TgroupSchema
+  person(name: String, maxCount: Float, queryString: String): Tperson__groupSchema
 }
 
-type TgroupSchema {
+type Tperson__groupSchema {
   name: String
   purpose: String!
 }

--- a/src/autogen/test/graphql-schemas/09-top-level-fields.graphql
+++ b/src/autogen/test/graphql-schemas/09-top-level-fields.graphql
@@ -5,10 +5,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): TpersonSchema
+  person(name: String, maxCount: Float, queryString: String): Tperson__personSchema
 }
 
-type TpersonSchema {
+type Tperson__personSchema {
   address: String
   name: String!
 }

--- a/src/autogen/test/graphql-schemas/10-subrecord.graphql
+++ b/src/autogen/test/graphql-schemas/10-subrecord.graphql
@@ -2,15 +2,15 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): Tgenerated1
+  person(name: String, maxCount: Float, queryString: String): Tperson__generated1
 }
 
-type Tgenerated1 {
-  address: Tgenerated1_address
+type Tperson__generated1 {
+  address: Tperson__generated1_address
   name: String!
 }
 
-type Tgenerated1_address {
+type Tperson__generated1_address {
   city: String!
   district: String
   streetAddress: String!

--- a/src/autogen/test/graphql-schemas/11-schema-includes-schema.graphql
+++ b/src/autogen/test/graphql-schemas/11-schema-includes-schema.graphql
@@ -5,7 +5,7 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): TtopSchema
+  person(name: String, maxCount: Float, queryString: String): Tperson__topSchema
 }
 
 type T_schemas_metadata {
@@ -17,7 +17,7 @@ type T_schemas_metadata {
   updatedDate: String
 }
 
-type TtopSchema {
+type Tperson__topSchema {
   address: String
   metadata: T_schemas_metadata
   name: String!

--- a/src/autogen/test/graphql-schemas/12-array-of-scalars.graphql
+++ b/src/autogen/test/graphql-schemas/12-array-of-scalars.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): Tgenerated1
+  person(name: String, maxCount: Float, queryString: String): Tperson__generated1
 }
 
-type Tgenerated1 {
+type Tperson__generated1 {
   address: String
   aliases: [String]
   name: String!

--- a/src/autogen/test/graphql-schemas/13-array-of-arrays.graphql
+++ b/src/autogen/test/graphql-schemas/13-array-of-arrays.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): Tgenerated1
+  person(name: String, maxCount: Float, queryString: String): Tperson__generated1
 }
 
-type Tgenerated1 {
+type Tperson__generated1 {
   address: String
   aliases: [[String]]
   name: String!

--- a/src/autogen/test/graphql-schemas/14-array-of-structures.graphql
+++ b/src/autogen/test/graphql-schemas/14-array-of-structures.graphql
@@ -2,16 +2,16 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): Tgenerated1
+  person(name: String, maxCount: Float, queryString: String): Tperson__generated1
 }
 
-type Tgenerated1 {
+type Tperson__generated1 {
   address: String
-  aliases: [Tgenerated1_aliases]
+  aliases: [Tperson__generated1_aliases]
   name: String
 }
 
-type Tgenerated1_aliases {
+type Tperson__generated1_aliases {
   alias: String
   inUseSince: Int
 }

--- a/src/autogen/test/graphql-schemas/15-array-of-structures-with-array.graphql
+++ b/src/autogen/test/graphql-schemas/15-array-of-structures-with-array.graphql
@@ -2,16 +2,16 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): Tgenerated1
+  person(name: String, maxCount: Float, queryString: String): Tperson__generated1
 }
 
-type Tgenerated1 {
+type Tperson__generated1 {
   address: String
-  aliases: [Tgenerated1_aliases]
+  aliases: [Tperson__generated1_aliases]
   name: String
 }
 
-type Tgenerated1_aliases {
+type Tperson__generated1_aliases {
   alias: String
   inUseSince: Int
   othersUsingThisAlias: [String]

--- a/src/autogen/test/graphql-schemas/16-schema-includes-schema-includes-schema.graphql
+++ b/src/autogen/test/graphql-schemas/16-schema-includes-schema-includes-schema.graphql
@@ -5,7 +5,7 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): TtopSchema
+  person(name: String, maxCount: Float, queryString: String): Tperson__topSchema
 }
 
 type T_schemas_contained {
@@ -17,7 +17,7 @@ type T_schemas_subcontained {
   innerField: String
 }
 
-type TtopSchema {
+type Tperson__topSchema {
   metadata: T_schemas_contained
   topLevelField: String
 }

--- a/src/autogen/test/graphql-schemas/17-link-field.graphql
+++ b/src/autogen/test/graphql-schemas/17-link-field.graphql
@@ -2,7 +2,7 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): TpersonSchema
+  person(name: String, maxCount: Float, queryString: String): Tperson__personSchema
 }
 
 type T_alias {
@@ -10,7 +10,7 @@ type T_alias {
   inUseSinceYear: Int
 }
 
-type TpersonSchema {
+type Tperson__personSchema {
   address: String
   aliases(limit: Int = 10): [T_alias] # link: /aliases (personId=$id) -> records
   name: String!

--- a/src/autogen/test/graphql-schemas/18-link-field-in-two-places.graphql
+++ b/src/autogen/test/graphql-schemas/18-link-field-in-two-places.graphql
@@ -2,8 +2,8 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): TpersonSchema
-  people(queryString: String): TpeopleSchema
+  person(name: String, maxCount: Float, queryString: String): Tperson__personSchema
+  people(queryString: String): Tpeople__peopleSchema
 }
 
 type T_alias {
@@ -17,12 +17,12 @@ type T_personWithLink {
   name: String!
 }
 
-type TpeopleSchema {
+type Tpeople__peopleSchema {
   count: Int!
   records: [T_personWithLink]!
 }
 
-type TpersonSchema {
+type Tperson__personSchema {
   address: String
   aliases(limit: Int = 10): [T_alias] # link: /aliases (personId=$id) -> records
   name: String!

--- a/src/autogen/test/graphql-schemas/19-hyphens-in-type-name.graphql
+++ b/src/autogen/test/graphql-schemas/19-hyphens-in-type-name.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): Tperson_schema
+  person(name: String, maxCount: Float, queryString: String): Tperson__person_schema
 }
 
-type Tperson_schema {
+type Tperson__person_schema {
   address: String
   name: String!
 }

--- a/src/autogen/test/graphql-schemas/20-at-sign-in-fieldname.graphql
+++ b/src/autogen/test/graphql-schemas/20-at-sign-in-fieldname.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): Tgenerated1
+  person(name: String, maxCount: Float, queryString: String): Tperson__generated1
 }
 
-type Tgenerated1 {
+type Tperson__generated1 {
   _address: String
   name: String
 }

--- a/src/autogen/test/graphql-schemas/21-at-sign-in-type.graphql
+++ b/src/autogen/test/graphql-schemas/21-at-sign-in-type.graphql
@@ -2,7 +2,7 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): Tgenerated1
+  person(name: String, maxCount: Float, queryString: String): Tperson__generated1
 }
 
 type T_schemas_metadata {
@@ -14,7 +14,7 @@ type T_schemas_metadata {
   updatedDate: String
 }
 
-type Tgenerated1 {
+type Tperson__generated1 {
   _metadata: T_schemas_metadata
   name: String
 }

--- a/src/autogen/test/graphql-schemas/22-endpoint-with-no-json.graphql
+++ b/src/autogen/test/graphql-schemas/22-endpoint-with-no-json.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): Tgenerated1
+  person(name: String, maxCount: Float, queryString: String): Tperson__generated1
 }
 
-type Tgenerated1 {
+type Tperson__generated1 {
   address: String
   name: String
 }

--- a/src/autogen/test/graphql-schemas/24-parameter-at-end-of-path.graphql
+++ b/src/autogen/test/graphql-schemas/24-parameter-at-end-of-path.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person_SINGLE(personId: String!, name: String, maxCount: Float, queryString: String): TpersonSchema
+  person_SINGLE(personId: String!, name: String, maxCount: Float, queryString: String): Tperson_SINGLE__personSchema
 }
 
-type TpersonSchema {
+type Tperson_SINGLE__personSchema {
   address: String
   name: String!
 }

--- a/src/autogen/test/graphql-schemas/25-parameter-in-middle-of-path.graphql
+++ b/src/autogen/test/graphql-schemas/25-parameter-in-middle-of-path.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person_SINGLE_raw(personId: String!, name: String, maxCount: Float, queryString: String): TpersonSchema
+  person_SINGLE_raw(personId: String!, name: String, maxCount: Float, queryString: String): Tperson_SINGLE_raw__personSchema
 }
 
-type TpersonSchema {
+type Tperson_SINGLE_raw__personSchema {
   address: String
   name: String!
 }

--- a/src/autogen/test/graphql-schemas/26-multiple-parameters-in-path.graphql
+++ b/src/autogen/test/graphql-schemas/26-multiple-parameters-in-path.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person_SINGLE_friends_SINGLE_raw(personId: String!, friendId: String!, name: String, maxCount: Float, queryString: String): TpersonSchema
+  person_SINGLE_friends_SINGLE_raw(personId: String!, friendId: String!, name: String, maxCount: Float, queryString: String): Tperson_SINGLE_friends_SINGLE_raw__personSchema
 }
 
-type TpersonSchema {
+type Tperson_SINGLE_friends_SINGLE_raw__personSchema {
   address: String
   name: String!
 }

--- a/src/autogen/test/graphql-schemas/27-field-with-no-type.graphql
+++ b/src/autogen/test/graphql-schemas/27-field-with-no-type.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): Tgenerated1
+  person(name: String, maxCount: Float, queryString: String): Tperson__generated1
 }
 
-type Tgenerated1 {
+type Tperson__generated1 {
   address: String
   name: String!
 }

--- a/src/autogen/test/graphql-schemas/28-application-vnd-api-json.graphql
+++ b/src/autogen/test/graphql-schemas/28-application-vnd-api-json.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): TpersonSchema
+  person(name: String, maxCount: Float, queryString: String): Tperson__personSchema
 }
 
-type TpersonSchema {
+type Tperson__personSchema {
   address: String
   name: String!
 }

--- a/src/autogen/test/graphql-schemas/29-raml-1point0.graphql
+++ b/src/autogen/test/graphql-schemas/29-raml-1point0.graphql
@@ -2,10 +2,10 @@
 # raml-version: 1.0
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): TpersonSchema
+  person(name: String, maxCount: Float, queryString: String): Tperson__personSchema
 }
 
-type TpersonSchema {
+type Tperson__personSchema {
   address: String
   name: String!
 }

--- a/src/autogen/test/graphql-schemas/30-square-brackets-in-param.graphql
+++ b/src/autogen/test/graphql-schemas/30-square-brackets-in-param.graphql
@@ -2,10 +2,10 @@
 # raml-version: 0.9
 
 type Query {
-  person(na_me: String, maxC__ount: Float, queryString_code_: String): TpersonSchema
+  person(na_me: String, maxC__ount: Float, queryString_code_: String): Tperson__personSchema
 }
 
-type TpersonSchema {
+type Tperson__personSchema {
   address: String
   name: String!
 }

--- a/src/autogen/test/graphql-schemas/31-schema-loop.graphql
+++ b/src/autogen/test/graphql-schemas/31-schema-loop.graphql
@@ -2,7 +2,7 @@
 # raml-version: 0.9
 
 type Query {
-  person(name: String, maxCount: Float, queryString: String): TpersonSchema
+  person(name: String, maxCount: Float, queryString: String): Tperson__personSchema
 }
 
 type T_aliasWithLoop {
@@ -17,7 +17,7 @@ type T_personWithLinkAndLoop {
   name: String!
 }
 
-type TpersonSchema {
+type Tperson__personSchema {
   address: String
   aliases(limit: Int = 10): [T_aliasWithLoop] # link: /aliases (personId=$id) -> records
   name: String!

--- a/src/autogen/test/graphql-schemas/32-schema-in-subdir-includes-schema.graphql
+++ b/src/autogen/test/graphql-schemas/32-schema-in-subdir-includes-schema.graphql
@@ -2,7 +2,7 @@
 # raml-version: 0.9
 
 type Query {
-  person: TtopSchema
+  person: Tperson__topSchema
 }
 
 type T_schemas_metadata {
@@ -14,7 +14,7 @@ type T_schemas_metadata {
   updatedDate: String
 }
 
-type TtopSchema {
+type Tperson__topSchema {
   address: String
   metadata: T_schemas_metadata
   name: String!

--- a/src/autogen/test/graphql-schemas/33-raml-1point0-array-argument.graphql
+++ b/src/autogen/test/graphql-schemas/33-raml-1point0-array-argument.graphql
@@ -2,15 +2,15 @@
 # raml-version: 1.0
 
 type Query {
-  users(facets: [String]): TuserdataCollection
+  users(facets: [String]): Tusers__userdataCollection
 }
 
-type TuserdataCollection {
+type Tusers__userdataCollection {
   totalRecords: Int!
-  users: [TuserdataCollection_users]!
+  users: [Tusers__userdataCollection_users]!
 }
 
-type TuserdataCollection_users {
+type Tusers__userdataCollection_users {
   id: String!
   username: String
 }

--- a/src/autogen/test/graphql-schemas/35-raml-1point0-schema-in-subdir-includes-schema.graphql
+++ b/src/autogen/test/graphql-schemas/35-raml-1point0-schema-in-subdir-includes-schema.graphql
@@ -2,7 +2,7 @@
 # raml-version: 1.0
 
 type Query {
-  perms_permissions: TpermissionListObject
+  perms_permissions: Tperms_permissions__permissionListObject
 }
 
 type T_schemas_permission {
@@ -16,7 +16,7 @@ type T_schemas_permission {
   visible: Boolean
 }
 
-type TpermissionListObject {
+type Tperms_permissions__permissionListObject {
   permissions: [T_schemas_permission]!
   totalRecords: Int!
 }

--- a/src/autogen/test/graphql-schemas/36-empty-object.graphql
+++ b/src/autogen/test/graphql-schemas/36-empty-object.graphql
@@ -2,15 +2,15 @@
 # raml-version: 0.9
 
 type Query {
-  person: Tgenerated1
+  person: Tperson__generated1
 }
 
-type Tgenerated1 {
+type Tperson__generated1 {
   name: String
-  notes: Tgenerated1_notes
+  notes: Tperson__generated1_notes
 }
 
-type Tgenerated1_notes {
+type Tperson__generated1_notes {
   _dummy: String
 }
 

--- a/tests/20-merge-toy-schemas.js
+++ b/tests/20-merge-toy-schemas.js
@@ -33,6 +33,16 @@ const testCases = [
       [ true, /^type TadvancedPerson /m ],
     ],
   },
+  {
+    name: 'same schema name, different definition',
+    services: ['service1', 'service5'],
+    matches: [
+      [ true, /^# title: First/m ],
+      [ true, /^# title: .*Fifth/m ],
+      [ true, /^type Tperson /m ],
+      [ true, /^type TadvancedPerson /m ],
+    ],
+  },
 ];
 
 describe('20. merge toy schemas', () => {

--- a/tests/20-merge-toy-schemas.js
+++ b/tests/20-merge-toy-schemas.js
@@ -9,8 +9,8 @@ const testCases = [
     matches: [
       [ true, /^# title: First/m ],
       [ true, /^# title: .*Second/m ],
-      [ true, /^type Tperson /m ],
-      [ true, /^type TbasicPerson /m ],
+      [ true, /^type Tws1_person_SINGLE__person /m ],
+      [ true, /^type Tws2_person_SINGLE__basicPerson /m ],
     ],
   },
   {
@@ -19,8 +19,8 @@ const testCases = [
     matches: [
       [ true, /^# title: First/m ],
       [ true, /^# title: .*Third/m ],
-      [ true, /^type Tperson /m ],
-      [ false, /basicPerson/ ],
+      [ true, /^type Tws1_person_SINGLE__person /m ],
+      [ false, /type Tws3_person_SINGLE__basicPerson/ ],
     ],
   },
   {
@@ -29,8 +29,8 @@ const testCases = [
     matches: [
       [ true, /^# title: First/m ],
       [ true, /^# title: .*Fourth/m ],
-      [ true, /^type Tperson /m ],
-      [ true, /^type TadvancedPerson /m ],
+      [ true, /^type Tws1_person_SINGLE__person /m ],
+      [ true, /^type Tws4_person_SINGLE__advancedPerson /m ],
     ],
   },
   {
@@ -39,8 +39,19 @@ const testCases = [
     matches: [
       [ true, /^# title: First/m ],
       [ true, /^# title: .*Fifth/m ],
-      [ true, /^type Tperson /m ],
-      [ true, /^type TadvancedPerson /m ],
+      [ true, /^type Tws1_person_SINGLE__person /m ],
+      [ true, /^type Tws5_person_SINGLE__person /m ],
+    ],
+  },
+  {
+    name: 'schema included at multiple levels by different resources',
+    services: ['service1', 'service6'],
+    matches: [
+      [ true, /^# title: First/m ],
+      [ true, /^# title: .*Sixth/m ],
+      [ true, /^type T_basic_person /m ],
+      [ true, /^type Tws1_person_SINGLE__person /m ],
+      [ true, /^type Tws6_person_SINGLE__person /m ],
     ],
   },
 ];

--- a/tests/20-merge-toy-schemas.js
+++ b/tests/20-merge-toy-schemas.js
@@ -1,0 +1,64 @@
+import { describe, it } from 'mocha';
+import { assert } from 'chai';
+import { execSync } from 'child_process';
+
+const testCases = [
+  {
+    name: 'different schema name, matching definition',
+    services: ['service1', 'service2'],
+    matches: [
+      [ true, /^# title: First/m ],
+      [ true, /^# title: .*Second/m ],
+      [ true, /^type Tperson /m ],
+      [ true, /^type TbasicPerson /m ],
+    ],
+  },
+  {
+    name: 'same schema name, matching definition',
+    services: ['service1', 'service3'],
+    matches: [
+      [ true, /^# title: First/m ],
+      [ true, /^# title: .*Third/m ],
+      [ true, /^type Tperson /m ],
+      [ false, /basicPerson/ ],
+    ],
+  },
+  {
+    name: 'different schema name, different definition',
+    services: ['service1', 'service4'],
+    matches: [
+      [ true, /^# title: First/m ],
+      [ true, /^# title: .*Fourth/m ],
+      [ true, /^type Tperson /m ],
+      [ true, /^type TadvancedPerson /m ],
+    ],
+  },
+];
+
+describe('20. merge toy schemas', () => {
+  testCases.forEach(testCase => {
+    const { name, services, matches } = testCase;
+    const command = './src/autogen/raml2graphql ' + services.map(x => `tests/handmade-raml/${x}.raml`).join(' ');
+
+    it(name, (done) => {
+      let output;
+      try {
+        output = execSync(command);
+      } catch (e) {
+        console.error('failed:', typeof e, e.toString());
+        done(e);
+        return;
+      }
+
+      // The schema-merge suceeded; check that the output is the expected GraphQL schema
+      const s = output.toString();
+      // console.log(s);
+      matches.forEach(matchCase => {
+        const [shouldMatch, regexp] = matchCase;
+        const matches = s.match(regexp);
+        assert(!!matches === shouldMatch, (shouldMatch ? 'does not match' : 'matches') + ' ' + regexp);
+      });
+      done();
+    });
+  });
+});

--- a/tests/21-merge-production-schemas.js
+++ b/tests/21-merge-production-schemas.js
@@ -2,10 +2,9 @@
 
 import { describe, it } from 'mocha';
 import { assert } from 'chai';
+import { execSync } from 'child_process';
 
-const execSync = require('child_process').execSync;
-
-describe('20. merge production schemas', function () {
+describe('21. merge production schemas', function () {
   it('compile and merge', function (done) {
     this.timeout(10000);
 

--- a/tests/21-merge-production-schemas.js
+++ b/tests/21-merge-production-schemas.js
@@ -9,7 +9,7 @@ describe('21. merge production schemas', function () {
     this.timeout(10000);
 
     // XXX this must run against the same schemas listed on the CMD line of ../Dockerfile
-    const command = './src/autogen/raml2graphql ./build/schemas-for-build/mod-search/ramls/*.raml';
+    const command = './src/autogen/raml2graphql ./build/schemas-for-build/*/ramls/*.raml';
     let output;
     try {
       output = execSync(command);

--- a/tests/handmade-raml/advanced-person-example.json
+++ b/tests/handmade-raml/advanced-person-example.json
@@ -1,0 +1,5 @@
+{
+  "id": "123",
+  "firstName": "Mike",
+  "lastName": "Taylor"
+}

--- a/tests/handmade-raml/advanced-person.json
+++ b/tests/handmade-raml/advanced-person.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "An advanced representation of a person",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "unique identifier"
+    },
+    "firstName": {
+      "type": "string",
+      "description": "first name of the person"
+    },
+    "lastName": {
+      "type": "string",
+      "description": "last name of the person"
+    }
+  },
+  "required": ["id"],
+  "additionalProperties": false
+}

--- a/tests/handmade-raml/basic-person-example.json
+++ b/tests/handmade-raml/basic-person-example.json
@@ -1,0 +1,4 @@
+{
+  "id": "123",
+  "name": "Mike Taylor"
+}

--- a/tests/handmade-raml/basic-person.json
+++ b/tests/handmade-raml/basic-person.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A simple representation of a person",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "unique identifier"
+    },
+    "name": {
+      "type": "string",
+      "description": "name of the person"
+    }
+  },
+  "required": ["id"],
+  "additionalProperties": false
+}

--- a/tests/handmade-raml/person-with-manager-example.json
+++ b/tests/handmade-raml/person-with-manager-example.json
@@ -1,0 +1,8 @@
+{
+  "id": "123",
+  "name": "Mike Taylor",
+  "manager": {
+    "id": "456",
+    "name": "Fiona Taylor"
+  }
+}

--- a/tests/handmade-raml/person-with-manager.json
+++ b/tests/handmade-raml/person-with-manager.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A person who has a manager (who is also a person)",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "unique identifier"
+    },
+    "name": {
+      "type": "string",
+      "description": "name of the person"
+    },
+    "manager": {
+      "type": "object",
+      "$ref": "basic-person.json"
+    }
+  },
+  "required": ["id", "manager"],
+  "additionalProperties": false
+}

--- a/tests/handmade-raml/service1.raml
+++ b/tests/handmade-raml/service1.raml
@@ -1,0 +1,19 @@
+#%RAML 1.0
+title: First of three RAMLs that use a person schema
+
+# The GraphQL type name "Tperson" is generated from the RAML type name "person"
+# (not from the name of the JSON schema file "basic-person.json")
+
+types:
+  person: !include basic-person.json
+
+/ws1:
+  /person:
+    /{id}:
+      get:
+        responses:
+          200:
+            body:
+              application/json:
+                type: person
+                example: !include basic-person-example.json

--- a/tests/handmade-raml/service2.raml
+++ b/tests/handmade-raml/service2.raml
@@ -9,7 +9,7 @@ title: Second of several RAMLs that use a person schema
 types:
   basicPerson: !include basic-person.json
 
-/ws3:
+/ws2:
   /person:
     /{id}:
       get:

--- a/tests/handmade-raml/service2.raml
+++ b/tests/handmade-raml/service2.raml
@@ -1,0 +1,21 @@
+#%RAML 1.0
+title: Second of several RAMLs that use a person schema
+
+# Uses the same schema (basic-person.json) as service1, named with a
+# different RAML type name ("basicPerson" instead of "person"). The
+# two services are compatible because the two definitions are of
+# different types (and also because they are identical anyway).
+
+types:
+  basicPerson: !include basic-person.json
+
+/ws3:
+  /person:
+    /{id}:
+      get:
+        responses:
+          200:
+            body:
+              application/json:
+                type: basicPerson
+                example: !include basic-person-example.json

--- a/tests/handmade-raml/service3.raml
+++ b/tests/handmade-raml/service3.raml
@@ -1,0 +1,19 @@
+#%RAML 1.0
+title: Third of several RAMLs that use a person schema
+# Uses the same schema (basic-person.json) as service1, named with the
+# same RAML type name ("person"). The two services are compatible
+# because the two definitions of the same type are identical.
+
+types:
+  person: !include basic-person.json
+
+/ws2:
+  /person:
+    /{id}:
+      get:
+        responses:
+          200:
+            body:
+              application/json:
+                type: person
+                example: !include basic-person-example.json

--- a/tests/handmade-raml/service3.raml
+++ b/tests/handmade-raml/service3.raml
@@ -1,5 +1,6 @@
 #%RAML 1.0
 title: Third of several RAMLs that use a person schema
+# 
 # Uses the same schema (basic-person.json) as service1, named with the
 # same RAML type name ("person"). The two services are compatible
 # because the two definitions of the same type are identical.

--- a/tests/handmade-raml/service3.raml
+++ b/tests/handmade-raml/service3.raml
@@ -8,7 +8,7 @@ title: Third of several RAMLs that use a person schema
 types:
   person: !include basic-person.json
 
-/ws2:
+/ws3:
   /person:
     /{id}:
       get:

--- a/tests/handmade-raml/service4.raml
+++ b/tests/handmade-raml/service4.raml
@@ -1,0 +1,21 @@
+#%RAML 1.0
+title: Fourth of several RAMLs that use a person schema
+
+# Uses a different schema (detailed-person.json) from service1, named
+# with a different RAML type name ("advancedPerson"). The two services
+# are compatible because the two different definitions do not use the
+# same type name.
+
+types:
+  advancedPerson: !include advanced-person.json
+
+/ws2:
+  /person:
+    /{id}:
+      get:
+        responses:
+          200:
+            body:
+              application/json:
+                type: advancedPerson
+                example: !include advanced-person-example.json

--- a/tests/handmade-raml/service4.raml
+++ b/tests/handmade-raml/service4.raml
@@ -9,7 +9,7 @@ title: Fourth of several RAMLs that use a person schema
 types:
   advancedPerson: !include advanced-person.json
 
-/ws2:
+/ws4:
   /person:
     /{id}:
       get:

--- a/tests/handmade-raml/service5.raml
+++ b/tests/handmade-raml/service5.raml
@@ -1,0 +1,21 @@
+#%RAML 1.0
+title: Fourth of several RAMLs that use a person schema
+
+# Uses a different schema (detailed-person.json) from service1, named
+# with the same RAML type name ("person"). The two services are
+# incompatible (until we fix MODGQL-114) because the two different
+# definitions are both trying to use the same type name.
+
+types:
+  person: !include advanced-person.json
+
+/ws2:
+  /person:
+    /{id}:
+      get:
+        responses:
+          200:
+            body:
+              application/json:
+                type: person
+                example: !include advanced-person-example.json

--- a/tests/handmade-raml/service5.raml
+++ b/tests/handmade-raml/service5.raml
@@ -9,7 +9,7 @@ title: Fourth of several RAMLs that use a person schema
 types:
   person: !include advanced-person.json
 
-/ws2:
+/ws5:
   /person:
     /{id}:
       get:

--- a/tests/handmade-raml/service5.raml
+++ b/tests/handmade-raml/service5.raml
@@ -1,5 +1,5 @@
 #%RAML 1.0
-title: Fourth of several RAMLs that use a person schema
+title: Fifth of several RAMLs that use a person schema
 
 # Uses a different schema (detailed-person.json) from service1, named
 # with the same RAML type name ("person"). The two services are

--- a/tests/handmade-raml/service6.raml
+++ b/tests/handmade-raml/service6.raml
@@ -1,0 +1,21 @@
+#%RAML 1.0
+title: Sixth of several RAMLs that use a person schema
+
+# Uses a different schema (detailed-person.json) from service1, named
+# with a different RAML type name ("advancedPerson"). The two services
+# are compatible because the two different definitions do not use the
+# same type name.
+
+types:
+  person: !include person-with-manager.json
+
+/ws6:
+  /person:
+    /{id}:
+      get:
+        responses:
+          200:
+            body:
+              application/json:
+                type: person
+                example: !include person-with-manager-example.json


### PR DESCRIPTION
Generated type names now include a prefix representing the WSAPI path, disambiguating otherwise same-named types from different modules. This prevents same-named schemas with different contents from colliding.

Fixes MODGQL-114.

The fix to type names enables `mod-inventory-storage` and `mod-search` to run together.

Fixes MODGQL-165.