### PR TITLE
MODGQL-174: run "apk upgrade" fixing openssl/libcrypto3 vulns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:18-alpine AS base
-RUN apk add --no-cache git
+
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+RUN apk upgrade \
+ && apk add git \
+ && rm -rf /var/cache/apk/*
+
 WORKDIR /usr/src/app
 
 # Create a Docker build stage cache layer with node_modules only


### PR DESCRIPTION
In Dockerfile run "apk upgrade".
This upgrades openssl/libcrypto3 from 3.1.3-r0 to 3.1.4-r1 fixing Encryption Weakness and Denial of Service:
* https://nvd.nist.gov/vuln/detail/CVE-2023-5363
* https://nvd.nist.gov/vuln/detail/CVE-2023-5678