### PR TITLE
MODGQL-175 Move all babel 6 deps to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
   "dependencies": {
     "@folio/stripes-logger": "^0.0.2",
     "apollo-server-express": "^2.15.0",
-    "babel-cli": "^6.26.0",
-    "babel-preset-env": "^1.6.1",
-    "babel-preset-stage-2": "^6.24.1",
     "express": "^4.17.3",
     "graphql": "^15.1.0",
     "js-yaml": "^3.14.0",
@@ -35,7 +32,10 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.2.100061",
+    "babel-cli": "^6.26.0",
     "babel-eslint": "^10.1.0",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-stage-2": "^6.24.1",
     "babel-register": "^6.26.0",
     "chai": "^4.1.2",
     "chai-http": "^4.3.0",


### PR DESCRIPTION
Moving babel 6 build tools to devDeps seems the lighter weight change vs upgrading to babel v7. Based on a cursory search, it appears these tools are only used at build time and not at runtime.

https://issues.folio.org/browse/MODGQL-175