### PR TITLE
Revert "Move all babel 6 deps to devDependencies (#115)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "dependencies": {
     "@folio/stripes-logger": "^0.0.2",
     "apollo-server-express": "^2.15.0",
+    "babel-cli": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-stage-2": "^6.24.1",
     "express": "^4.17.3",
     "graphql": "^15.1.0",
     "js-yaml": "^3.14.0",
@@ -32,10 +35,7 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.2.100061",
-    "babel-cli": "^6.26.0",
     "babel-eslint": "^10.1.0",
-    "babel-preset-env": "^1.6.1",
-    "babel-preset-stage-2": "^6.24.1",
     "babel-register": "^6.26.0",
     "chai": "^4.1.2",
     "chai-http": "^4.3.0",


### PR DESCRIPTION
This reverts commit eb2821b71e9f9a4b01dcc3b905acd122e7c6636b.

The `yarn start` command (which is invoked as the Docker container's `RUN` command) uses babel, so that translation happens at startup time. So that obviously fails now Babel is just a dev-dependency.

There are various better approaches we could take, but for now the main thing is just to make it work again,