### PR TITLE
MODGQL-204: xmldom 0.6.0 fixing vulns

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "minimist": "^1.2.5",
     "underscore": "^1.13.1",
     "validator": "^13.15.22",
+    "xmldom": "^0.6.0",
     "@xmldom/xmldom": "^0.8.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8349,10 +8349,10 @@ xmlbuilder@~9.0.1:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
   integrity sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==
 
-xmldom@0.1.27:
-  version "0.1.27"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
-  integrity sha512-7WpJBYwyhvsddFJA51SOIU0Be9W44sbGGjc6Z3ly8Wx/Wl7nriMPZ5xf6Np9ASlJ6gACfXcTLukm4DtX372lFw==
+xmldom@0.1.27, xmldom@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.6.0.tgz#43a96ecb8beece991cef382c08397d82d4d0c46f"
+  integrity sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==
 
 xmlhttprequest@1.8.0:
   version "1.8.0"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODGQL-204

Bump xmldom from ^0.1.27 to ^0.6.0 fixing
* https://www.cve.org/CVERecord?id=CVE-2026-41674
* https://www.cve.org/CVERecord?id=CVE-2026-34601
* https://www.cve.org/CVERecord?id=CVE-2026-41673
* https://www.cve.org/CVERecord?id=CVE-2026-41672
* https://www.cve.org/CVERecord?id=CVE-2026-41675