### PR TITLE
MODGQL-205: Bump underscore from 1.13.1 to 1.13.8 fixing CVE-2026-27601

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "glob-parent": "^5.1.2",
     "json-ptr": "^3.0.0",
     "minimist": "^1.2.5",
-    "underscore": "^1.13.1",
+    "underscore": "^1.13.8",
     "validator": "^13.15.22",
     "@xmldom/xmldom": "^0.8.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7981,10 +7981,10 @@ undefsafe@^2.0.5:
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.5.tgz#38733b9327bdcd226db889fb723a6efd162e6e2c"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
-underscore@1.9.1, underscore@^1.13.1:
-  version "1.13.7"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.7.tgz#970e33963af9a7dda228f17ebe8399e5fbe63a10"
-  integrity sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==
+underscore@1.9.1, underscore@^1.13.8:
+  version "1.13.8"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.8.tgz#a93a21186c049dbf0e847496dba72b7bd8c1e92b"
+  integrity sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==
 
 undici-types@~7.8.0:
   version "7.8.0"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODGQL-205

Bump underscore from 1.13.1 to 1.13.8 to fix this security vulnerability:

* https://www.cve.org/CVERecord?id=CVE-2026-27601 – https://github.com/jashkenas/underscore/security/advisories/GHSA-qpx9-hpmf-5gmw – unlimited recursion (DoS) in _.flatten and _.isEqual